### PR TITLE
Fix: release action flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           yarn build
           mkdir ${{ env.PLUGIN_NAME }}
           cp README.md package.json extract.svg Extract_v2.gif ${{ env.PLUGIN_NAME }}
-          mv dist ${{ env.PLUGIN_NAME }}
+          mv dist/* ${{ env.PLUGIN_NAME }} && rm -rf dist
           zip -r ${{ env.PLUGIN_NAME }}.zip ${{ env.PLUGIN_NAME }}
           ls
           echo "::set-output name=tag_name::$(git tag --sort version:refname | tail -n 1)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "logseq-extract-plugin",
-    "version": "1.0.0",
+    "version": "1.0.2",
     "description": "Extract highlighted/bold content from block. Optionally, you can set the regex in settings to get what you want.",
     "main": "index.html",
     "author": "Sidharth Panwar",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "logseq-extract-plugin",
-    "version": "1.0.2",
+    "version": "1.0.5",
     "description": "Extract highlighted/bold content from block. Optionally, you can set the regex in settings to get what you want.",
     "main": "index.html",
     "author": "Sidharth Panwar",
@@ -19,5 +19,8 @@
     "logseq": {
         "id": "logseq-extract",
         "icon": "./extract.svg"
-    }
+    },
+    "browserslist": [
+        "chrome 80"
+    ]
 }


### PR DESCRIPTION
The corresponding Github-action Build release https://github.com/xyhp915/logseq-extract-plugin/releases/tag/1.0.5